### PR TITLE
some extra data for tracking in animeinfo extractor

### DIFF
--- a/src/extractors/animeInfo.extractor.js
+++ b/src/extractors/animeInfo.extractor.js
@@ -48,7 +48,7 @@ async function extractAnimeInfo(id) {
 
     const title = titleElement.text().trim();
     const japanese_title = titleElement.attr("data-jname");
-    const synonyms = $('.item.item-title span.name').text().trim();
+    const synonyms = $('.item.item-title:has(.item-head:contains("Synonyms")) .name').text().trim();
     const poster = posterElement.find("img").attr("src");
     const syncDataScript = $("#syncData").html();
     let anilistId = null;
@@ -155,7 +155,7 @@ async function extractAnimeInfo(id) {
       malId,
       title,
       japanese_title,
-      synonyms,
+      synonyms: null,
       poster,
       showType,
       animeInfo,

--- a/src/extractors/animeInfo.extractor.js
+++ b/src/extractors/animeInfo.extractor.js
@@ -49,6 +49,19 @@ async function extractAnimeInfo(id) {
     const title = titleElement.text().trim();
     const japanese_title = titleElement.attr("data-jname");
     const poster = posterElement.find("img").attr("src");
+    const syncDataScript = $("#syncData").html();
+    let anilistId = null;
+    let malId = null;
+
+    if (syncDataScript) {
+      try {
+        const syncData = JSON.parse(syncDataScript);
+        anilistId = syncData.anilist_id || null;
+        malId = syncData.mal_id || null;
+      } catch (error) {
+        console.error("Error parsing syncData:", error);
+      }
+    }
 
     const animeInfo = {};
     element.each((_, el) => {
@@ -137,6 +150,8 @@ async function extractAnimeInfo(id) {
       adultContent,
       data_id,
       id: season_id,
+      anilistId,
+      malId,
       title,
       japanese_title,
       poster,

--- a/src/extractors/animeInfo.extractor.js
+++ b/src/extractors/animeInfo.extractor.js
@@ -48,6 +48,7 @@ async function extractAnimeInfo(id) {
 
     const title = titleElement.text().trim();
     const japanese_title = titleElement.attr("data-jname");
+    const synonyms = $('.item.item-title span.name').text().trim();
     const poster = posterElement.find("img").attr("src");
     const syncDataScript = $("#syncData").html();
     let anilistId = null;
@@ -154,6 +155,7 @@ async function extractAnimeInfo(id) {
       malId,
       title,
       japanese_title,
+      synonyms,
       poster,
       showType,
       animeInfo,

--- a/src/extractors/animeInfo.extractor.js
+++ b/src/extractors/animeInfo.extractor.js
@@ -155,7 +155,7 @@ async function extractAnimeInfo(id) {
       malId,
       title,
       japanese_title,
-      synonyms: null,
+      synonyms,
       poster,
       showType,
       animeInfo,


### PR DESCRIPTION
in the anime info data i have added just 3 new data , if anyone want to integrate anilist or mal tracking in there site they can use this info 
and extra unnecessary info synonym 

 "anilistId": "163134",
 "malId": "54857",
 "synonyms": "Re: Life in a different world from zero 3rd Season, ReZero 3rd Season, Re:Zero - Starting Life in Another World 3",