### PR TITLE
Extract Related Anime Only + Add Japanese Title to Animeography

### DIFF
--- a/src/extractors/characters.extractor.js
+++ b/src/extractors/characters.extractor.js
@@ -43,8 +43,11 @@ export async function extractCharacter(id) {
     const animeography = [];
     $(".anif-block-ul li").each((_, el) => {
       const item = $(el);
-      const title = item.find(".film-name a").text().trim();
-      const id = item.find(".film-name a").attr("href")?.split("/").pop();
+      const anchor = item.find(".film-name a.dynamic-name");
+
+      const title = anchor.text().trim();
+      const japanese_title = anchor.attr("data-jname")?.trim();
+      const id = anchor.attr("href")?.split("/").pop();
       const role = item.find(".fdi-item").first().text().trim();
       const type = item.find(".fdi-item").last().text().trim();
       const poster = item.find(".film-poster img").attr("src");
@@ -52,6 +55,7 @@ export async function extractCharacter(id) {
       if (title && id) {
         animeography.push({
           title,
+          japanese_title,
           id,
           role: role.replace(" (Role)", ""),
           type,

--- a/src/extractors/related.extractor.js
+++ b/src/extractors/related.extractor.js
@@ -1,59 +1,42 @@
 export default async function extractRelatedData($) {
-  const relatedElements = $(
-    "#main-sidebar .block_area_sidebar .block_area-content .cbox-list .cbox-content .anif-block-ul .ulclear li"
+  // Target only the section that contains "Related Anime" heading
+  const relatedSection = $('#main-sidebar .block_area:has(.cat-heading:contains("Related Anime"))');
+
+  const relatedElements = relatedSection.find(
+    ".anif-block-ul .ulclear li"
   );
+
   return await Promise.all(
     relatedElements
       .map(async (index, element) => {
-        const id = $(element)
-          .find(".film-detail .film-name a")
-          .attr("href")
-          .split("/")
-          .pop();
-        const data_id = $(element).find(".film-poster").attr("data-id");
-        const title = $(element)
-          .find(".film-detail .film-name a")
-          .text()
-          .trim();
-        const japanese_title = $(element)
-          .find(".film-detail .film-name a")
-          .attr("data-jname")
-          .trim();
-        const poster = $(element).find(".film-poster img").attr("data-src");
-        const $fdiItems = $(".film-detail>.fd-infor>.tick", element);
-        const showType = $fdiItems
-          .filter((_, item) => {
-            const text = $(item).text().trim().toLowerCase();
-            return ["tv", "ona", "movie", "ova", "special"].some((type) =>
-              text.includes(type)
-            );
-          })
-          .first()
-          .text()
-          .trim()
-          .split(/\s+/)
-          .find((word) =>
-            ["tv", "ona", "movie", "ova", "special"].includes(
-              word.toLowerCase()
-            )
-          );
+        const $el = $(element);
+        const id = $el.find(".film-detail .film-name a").attr("href")?.split("/").pop();
+        const data_id = $el.find(".film-poster").attr("data-id");
+        const title = $el.find(".film-detail .film-name a").text().trim();
+        const japanese_title = $el.find(".film-detail .film-name a").attr("data-jname")?.trim();
+        const poster = $el.find(".film-poster img").attr("data-src") || $el.find(".film-poster img").attr("src");
+
+        // Extract show type like "TV", "Movie", etc.
+        const showTypeText = $el.find(".tick").text().toLowerCase();
+        const showTypeMatch = ["TV", "ONA", "Movie", "OVA", "Special"].find(type =>
+          showTypeText.toLowerCase().includes(type.toLowerCase())
+        );
         const tvInfo = {
-          showType: showType ? showType : "Unknown",
+          showType: showTypeMatch || "Unknown"
         };
 
-        ["sub", "dub", "eps"].forEach((property) => {
-          const value = $(`.tick .tick-${property}`, element).text().trim();
+        // Extract tick items like sub, dub, eps
+        ["sub", "dub", "eps"].forEach((type) => {
+          const value = $el.find(`.tick-item.tick-${type}`).text().trim();
           if (value) {
-            tvInfo[property] = value;
+            tvInfo[type] = value;
           }
         });
-        let adultContent = false;
-        const tickRateText = $(".film-poster>.tick-rate", element)
-          .text()
-          .trim();
-        if (tickRateText.includes("18+")) {
-          adultContent = true;
-        }
+
+        // Adult content check
+        const tickRateText = $el.find(".film-poster > .tick-rate").text().trim();
+        const adultContent = tickRateText.includes("18+");
+
         return {
           data_id,
           id,


### PR DESCRIPTION
This PR improves the animeography data extraction by:

✅ Key Changes:
Filters extraction to only the "Related Anime" section in the sidebar to avoid pulling unrelated content like "Most Popular".

Adds support for extracting Japanese titles (japanese_title) from the data-jname attribute of anime links.

Ensures clean and accurate animeography results, now including both English and Japanese names.

📌 Context:
Previously, the scraper:

Pulled anime from all sidebar sections (including "Most Popular").

Did not extract Japanese titles from the animeography.

This PR fixes both.